### PR TITLE
Form Util Refactor

### DIFF
--- a/client/src/components/comments/comment_form.tsx
+++ b/client/src/components/comments/comment_form.tsx
@@ -3,13 +3,14 @@ import { connect } from 'react-redux';
 import { RootState } from '../../reducers/root_reducer';
 import { createComment, clearCommentErrors } from '../../actions/comment_actions';
 import { fetchPost } from "../../actions/post_actions";
+import { handleOk, handleImageFile } from "../../util/form_util";
 import {
     Modal,
     Form,
     Input,
     Typography,
 } from 'antd';
-import {FormWrapper} from "../../styles/form";
+import { FormWrapper } from "../../styles/form";
 
 interface Props {
     userId: number | null;
@@ -40,7 +41,8 @@ visible,
 closeModal,
 createComment,
 fetchPost,
-clearCommentErrors }) => {
+clearCommentErrors,
+ }) => {
     const [form] = Form.useForm();
     const formData = new FormData();
     const [imageState, setImageState] = useState('');
@@ -63,35 +65,10 @@ clearCommentErrors }) => {
             .catch(() => null)
     }
 
-    const handleOk = () => {
-        const waitForReset = () => new Promise((resolve) => {
-            resolve(clearCommentErrors())
-        })
-
-        waitForReset().then(() => {
-            form.submit();
-        })
-    };
-
-    const imageFile = (e : any) => {
-        const file = e.target.files[0];
-
-        if (file) {
-            const fileReader = new FileReader();
-            fileReader.readAsDataURL(file);
-
-            fileReader.onloadend = () => {
-                setImageState(file);
-            }
-        } else {
-            return setImageState('');
-        }
-    }
-
     return (
         <Modal
             visible={visible}
-            onOk={handleOk}
+            onOk={handleOk(clearCommentErrors, form)}
             onCancel={closeModal}
             okText='Create Comment'
             okButtonProps={{loading: loadingState}}>
@@ -137,7 +114,7 @@ clearCommentErrors }) => {
                     <Form.Item name="image"
                         label="Comment image"
                         colon={false}
-                        getValueFromEvent={imageFile}>
+                        getValueFromEvent={(e : any) => handleImageFile(e, setImageState)}>
                             <input type="file" accept="image/*" />
                     </Form.Item>
                 </Form>

--- a/client/src/components/notepads/notepad_form.tsx
+++ b/client/src/components/notepads/notepad_form.tsx
@@ -4,13 +4,14 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { RootState } from '../../reducers/root_reducer';
 import {  NewNotepad, Notepad } from '../../interfaces';
 import { createNotepad, clearNotepadErrors } from '../../actions/notepad_actions';
+import { handleOk } from "../../util/form_util";
 import {
     Modal,
     Form,
     Input,
     Typography
 } from 'antd';
-import {FormWrapper} from "../../styles/form";
+import { FormWrapper } from "../../styles/form";
 
 interface Props {
     user_id: number | null;
@@ -45,22 +46,10 @@ clearNotepadErrors }) => {
         });
     }
 
-    const waitForReset = () => (
-        new Promise((resolve) => {
-            resolve(clearNotepadErrors());
-        })
-    );
-
-    const handleOk = () => {
-        waitForReset().then(() => {
-            form.submit();
-        })
-    };
-
     return (
         <Modal
             visible={visible}
-            onOk={handleOk}
+            onOk={handleOk(clearNotepadErrors, form)}
             onCancel={closeModal}
             okText='Create Notepad'>
             <Typography.Title level={3} style={{ color: '#fff', marginBottom: '1em' }}>Create a Notepad</Typography.Title>

--- a/client/src/components/posts/post_form.tsx
+++ b/client/src/components/posts/post_form.tsx
@@ -3,13 +3,14 @@ import { connect } from 'react-redux';
 import { RootState } from '../../reducers/root_reducer';
 import {  NewPost } from '../../interfaces';
 import { createPost, clearPostErrors } from '../../actions/post_actions';
+import { handleOk, handleImageFile } from "../../util/form_util";
 import {
     Modal,
     Form,
     Input,
     Typography,
 } from 'antd';
-import {FormWrapper} from "../../styles/form";
+import { FormWrapper } from "../../styles/form";
 
 interface Props {
     userId: number | null;
@@ -32,6 +33,7 @@ const PostForm : React.FC<Props> = ({ userId, notepadId, notepadName, errors, vi
     const formData = new FormData();
     const [imageState, setImageState] = useState('');
     const [loadingState, setLoadingState] = useState<boolean>(false);
+
     const handleSubmit = async(values : NewPost) => {
         setLoadingState(true);
         formData.append('title', values.title);
@@ -46,37 +48,10 @@ const PostForm : React.FC<Props> = ({ userId, notepadId, notepadName, errors, vi
             .catch(() => null)
     }
 
-    const waitForReset = () => (
-        new Promise((resolve) => {
-            resolve(clearPostErrors());
-        })
-    );
-
-    const handleOk = () => {
-        waitForReset().then(() => {
-            form.submit();
-        })
-    };
-
-    const imageFile = (e : any) => {
-        const file = e.target.files[0];
-
-        if (file) {
-            const fileReader = new FileReader();
-            fileReader.readAsDataURL(file);
-
-            fileReader.onloadend = () => {
-                setImageState(file);
-            }
-        } else {
-            return setImageState('');
-        }
-    }
-
     return (
         <Modal
             visible={visible}
-            onOk={handleOk}
+            onOk={handleOk(clearPostErrors, form)}
             onCancel={closeModal}
             okText='Create Post'
             okButtonProps={{loading: loadingState}}>
@@ -130,7 +105,7 @@ const PostForm : React.FC<Props> = ({ userId, notepadId, notepadName, errors, vi
                     <Form.Item name="image"
                         label="Post image"
                         colon={false}
-                        getValueFromEvent={imageFile}>
+                        getValueFromEvent={(e : any) => handleImageFile(e, setImageState)}>
                             <input type="file" accept="image/*" />
                     </Form.Item>
                 </Form>

--- a/client/src/components/session/session_button.tsx
+++ b/client/src/components/session/session_button.tsx
@@ -1,10 +1,12 @@
 import React, { useState, lazy, Suspense } from 'react';
 import { connect } from 'react-redux';
-import {
-    Form, Button
-} from 'antd';
-import Modal from 'antd/lib/modal/Modal';
 import { clearSessionErrors } from '../../actions/user_actions';
+import {handleOk} from "../../util/form_util";
+import {
+Form,
+Button,
+Modal
+} from 'antd';
 
 const RegisterForm = lazy(() => import('./register_form'));
 const LoginForm = lazy(() => import('./login_form'));
@@ -22,25 +24,12 @@ const SessionButton : React.FC<Props> = ({ formType, loadingState, setLoadingSta
     const [modalState, setModalState] = useState<boolean>(false);
 
     const isRegister = formType === 'register';
-    const modalButtonAction = isRegister ? registerForm.submit : loginForm.submit;
 
     const closeAndReset = () => {
         setModalState(false);
         registerForm.resetFields();
         loginForm.resetFields();
         clearSessionErrors();
-    };
-
-    const waitForReset = () => (
-        new Promise((resolve) => {
-            resolve(clearSessionErrors());
-        })
-    );
-
-    const handleOk = () => {
-        waitForReset().then(() => {
-            modalButtonAction();
-        })
     };
     
     return (
@@ -49,7 +38,7 @@ const SessionButton : React.FC<Props> = ({ formType, loadingState, setLoadingSta
             { formType }
         </Button>
         <Modal visible={modalState}
-            onOk={handleOk}
+            onOk={handleOk(clearSessionErrors, isRegister ? registerForm : loginForm)}
             onCancel={() => closeAndReset()}
             okText={isRegister ? 'Register' : 'Login'}
             okButtonProps={{loading: loadingState}}>

--- a/client/src/util/form_util.ts
+++ b/client/src/util/form_util.ts
@@ -1,0 +1,32 @@
+import { Dispatch, SetStateAction } from 'react';
+import { clearCommentErrors } from "../actions/comment_actions";
+import { clearSessionErrors } from "../actions/user_actions";
+import { clearNotepadErrors } from "../actions/notepad_actions";
+import { clearPostErrors } from "../actions/post_actions";
+import { FormInstance } from "antd/lib/form";
+
+type ClearErrorTypes = typeof clearCommentErrors |
+    typeof clearSessionErrors |
+    typeof clearNotepadErrors |
+    typeof clearPostErrors
+
+export const handleOk = (clearErrors : ClearErrorTypes, form : FormInstance) => () => {
+    const waitForReset = () => new Promise((resolve => resolve(clearErrors())));
+
+    waitForReset().then(() => form.submit());
+};
+
+export const handleImageFile = (e : any, setImageState : Dispatch<SetStateAction<string>>) => {
+    const file = e.target.files[0];
+
+    if (file) {
+        const fileReader = new FileReader();
+        fileReader.readAsDataURL(file);
+
+        fileReader.onloadend = () => {
+            setImageState(file);
+        }
+    } else {
+        return setImageState('');
+    }
+}


### PR DESCRIPTION
Moved shared form actions to util file to keep code dry.  
  
Functions moved:  
* `handleOk` - returns callback that wraps error clearing actions in a promise, then calls it before form submit  
* `handleImageFile` - handles image upload for posts/comments