### PR TITLE
Fixed notepad search bar icon color

### DIFF
--- a/client/src/components/notepads/notepad_index.tsx
+++ b/client/src/components/notepads/notepad_index.tsx
@@ -15,7 +15,8 @@ interface Props {
 }
 
 const notepadConvert = (notepads : Notepad[], loading : boolean) => {
-    const items = notepads.map((notepad, idx) => <NotepadIndexItem notepad={notepad} key={idx} idx={idx} loading={loading} />)
+    const items = notepads.map((notepad, idx) =>
+        <NotepadIndexItem notepad={notepad} key={idx} idx={idx} loading={loading} />)
 
     return (
         <>

--- a/client/src/components/notepads/notepad_search.tsx
+++ b/client/src/components/notepads/notepad_search.tsx
@@ -24,6 +24,15 @@ const AutoCompleteWrapper = styled.div`
     .ant-input-affix-wrapper-lg .ant-input-search-icon::before {
         border-color: #747474;
     }
+    
+    .anticon-search {
+        opacity: 0.5;
+        
+        &:hover {
+            opacity: 1;
+            color: #fff;
+        }
+    }
 `;
 
 const createOption = (notepad : Notepad) => {


### PR DESCRIPTION
Resolves #7   
  
Notepad search bar icon color was originally incorrect on hover, now works as intended